### PR TITLE
Use flex shorthand for sponsors.

### DIFF
--- a/public/css/components/sections/_sponsors.scss
+++ b/public/css/components/sections/_sponsors.scss
@@ -15,6 +15,7 @@
   background: #fff;
   padding: 20px;
   margin: 10px;
+  flex: 1 1 200px;
 }
 
 .sponsor h3 {
@@ -23,8 +24,6 @@
 
 .shepherd {
   flex-grow: 3;
-  flex-shrink: 0;
-  flex-basis: content;
 }
 
 .shepherd .logo {
@@ -37,12 +36,6 @@
     width: 100%;
     height: auto;
   }
-}
-
-.cdn {
-  flex-grow: 1;
-  flex-shrink: 0;
-  flex-basis: content;
 }
 
 .cdn .logo {


### PR DESCRIPTION
We want to set a default grow and shirnk of 1 so sponsors grow and
shrink as room is available.
In addition, we want to set flex-basis to 200px which is the minimum
size we want sponsors to be. This will allow the flex boxes to break and
go into multiple rows and eventually a column naturally.