### PR TITLE
Fix a syntax error in the videojs.com home page (missing </a> end tag)

### DIFF
--- a/_harp/_users.ejs
+++ b/_harp/_users.ejs
@@ -2,6 +2,6 @@
   <li><a href="http://instagram.com" target="_blank"><img src="/img/company-logos/instagram.png" alt="Instagram"></a></li>
 	<li><a href="http://twitter.com" target="_blank"><img src="/img/company-logos/twitter.png" alt="Twitter"></a></li>
   <li><a href="http://microsoft.com" target="_blank"><img src="/img/company-logos/microsoft.png" alt="Microsoft"></a></li>
-	<li><a href="http://dropbox.com" target="_blank"><img src="/img/company-logos/dropbox.png" alt="Dropbox"></li>
+	<li><a href="http://dropbox.com" target="_blank"><img src="/img/company-logos/dropbox.png" alt="Dropbox"></a></li>
 	<li><a href="http://github.com" target="_blank"><img src="/img/company-logos/github.png" alt="Github"></a></li>
 </ul>


### PR DESCRIPTION
Fix a syntax error in the videojs.com home page's HTML which was causing the [W3C HTML Validator to choke](https://validator.w3.org/nu/?doc=http%3A%2F%2Fvideojs.com%2F). Fixes #35.