### PR TITLE
Add an error tracker

### DIFF
--- a/_harp/_layout.ejs
+++ b/_harp/_layout.ejs
@@ -31,6 +31,13 @@
 
   <script src="//vjs.zencdn.net/5-unsafe/video.js"></script>
   <script src="https://src.litix.io/videojs/1/videojs-mux.js"></script>
+
+  <!-- BEGIN TRACKJS -->
+  <script type="text/javascript">
+    window._trackJs = { token: "656d5cc5b34e4a84bbb61584aeb90b6e", application: "videojscom" };
+  </script>
+  <script src="https://d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js"></script>
+  <!-- END TRACKJS -->
 </head>
 <body id="<%= current.path.join('_') %>">
   <header>

--- a/_harp/index.ejs
+++ b/_harp/index.ejs
@@ -7,7 +7,16 @@
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
   <script>
-    videojs('preview-player', { "fluid": true, plugins: { mux: {} } });
+    try {
+      var player = window.player = videojs('preview-player', { "fluid": true, plugins: { mux: {} } });
+    } catch(err) {
+      trackJs.track(err);
+      throw err;
+    }
+
+    player.on('error', function(){
+      trackJs.track(player.error());
+    });
   </script>
 
   <script type="text/template" id="overlay-template">


### PR DESCRIPTION
Anyone mind if I try out an error tracker or two on videojs.com? I'm interested to know what they can show, and what kind of playback errors we're seeing with the basic player.

I'm trying TrackJS first, but also want to try Sentry.