### PR TITLE
Use a default version number and try to get the latest from npmcdn

### DIFF
--- a/_src-js/index.js
+++ b/_src-js/index.js
@@ -9,7 +9,7 @@ hljs.initHighlightingOnLoad();
 
 // Get the package information for doing things like swapping out version numbers
 getPackage(function(e, pkg) {
-  if (e) return console.error(e);
+  if (e) console.error(e);
 
   $('.vjs-version').text(pkg.version);
   $('.ie8-version').text(pkg.dependencies['videojs-ie8']);

--- a/_src-js/lib/vjs-version.js
+++ b/_src-js/lib/vjs-version.js
@@ -1,32 +1,36 @@
 import http from 'http';
 
 let pkgUrl = {
-  host: 'crossorigin.me',
-  path: '/https://registry.npmjs.org/video.js/latest'
+  host: 'npmcdn.com',
+  path: '/video.js@latest/package.json'
 };
 
 function getPackage(cb) {
-  cb(null, {
+  const defaults = {
     version: "5.8.8",
     dependencies: {
       "videojs-ie8": "1.1.2"
     }
+  };
+
+  http.get({host: pkgUrl.host, path: pkgUrl.path, withCredentials: false}, function(res) {
+    var body = '';
+    res.on('data', function(d) {
+      body += d;
+    });
+
+    res.on('end', function(e) {
+      try {
+        body = JSON.parse(body);
+      } catch (e) {
+        body = defaults;
+      }
+      cb(null, body);
+    });
+
+  }).on('error', function(e) {
+    cb(e, defaults);
   });
-
-  //http.get({host: pkgUrl.host, path: pkgUrl.path, withCredentials: false}, function(res) {
-    //var body = '';
-    //res.on('data', function(d) {
-      //body += d;
-    //});
-
-    //res.on('end', function(e) {
-      //body = JSON.parse(body);
-      //cb(null, body);
-    //});
-
-  //}).on('error', function(e) {
-    //cb(e);
-  //});
 }
 
 export { getPackage };


### PR DESCRIPTION
npmcdn.com is specifically made to return back npm package information in a CORS-accessible way.

```sh
$ curl -ILs http://npmcdn.com/video.js@latest/package.json
HTTP/1.1 301 Moved Permanently
Date: Fri, 15 Apr 2016 21:24:29 GMT
Location: https://npmcdn.com/video.js@latest/package.json

HTTP/1.1 302 Found
Date: Fri, 15 Apr 2016 21:24:29 GMT
Connection: keep-alive
Access-Control-Allow-Origin: *
Cache-Control: public, max-age=500
Location: /video.js@5.8.8/package.json

HTTP/1.1 200 OK
Date: Fri, 15 Apr 2016 21:24:30 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 2860
Connection: keep-alive
Access-Control-Allow-Origin: *
Cache-Control: public, max-age=31536000
```

Also, there's a defaults version for both that if the request fails or the response fails to parse as JSON we can use instead.