### PR TITLE
Add link to setup guide from getting-started

### DIFF
--- a/_harp/getting-started/index.ejs
+++ b/_harp/getting-started/index.ejs
@@ -90,6 +90,8 @@
   &lt;script src="http://vjs.zencdn.net/<span class="vjs-version">vjs-version</span>/video.js"&gt;&lt;/script&gt;
 &lt;/body&gt;</code></pre>
 
+      <p>For more detailed information, please see the <a href="http://docs.videojs.com/docs/guides/setup.html">setup documentation</a></p>
+
       <h3 id="download-npm">Install via npm</h3>
       <p>For more advanced workflows, installing via <a href="http://npmjs.com">npm</a> is recommended</p>
       <pre><code>$ npm install --save-dev video.js</code></pre>


### PR DESCRIPTION
We talk about the GA tracker in the setup documentation but not the quick start guide, so this makes it easier for people to get to the detailed setup docs.
