### PR TITLE
Update almost all links to HTTPS, replace single quotes with double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # videojs.com (the [video.js](https://github.com/videojs/video.js) website)
 
-The site uses [Harp](http://harpjs.com) as the main framework. It also uses [Browserify](http://browserify.com) and [Babel](https://github.com/babel/babelify) for ES2015 (javascript) modules.
+The site uses [Harp](https://harpjs.com) as the main framework. It also uses [Browserify](http://browserify.com) and [Babel](https://github.com/babel/babelify) for ES2015 (javascript) modules.
 
 
 ### Setup

--- a/_harp/_footer.ejs
+++ b/_harp/_footer.ejs
@@ -9,8 +9,8 @@
       <a href="https://twitter.com/videojs" class="button white" target="_blank"><i class="fa fa-twitter"></i> @videojs</a>
     </li>
     <li>
-      <a href="http://zencoder.us2.list-manage2.com/subscribe?u=36f130c3d3fadb2a21d2983b7&id=0f35b0535c" class="button white" target="_blank"><i class="fa fa-envelope"></i> Newsletter</a>
+      <a href="https://zencoder.us2.list-manage2.com/subscribe?u=36f130c3d3fadb2a21d2983b7&id=0f35b0535c" class="button white" target="_blank"><i class="fa fa-envelope"></i> Newsletter</a>
     </li>
-    <li><a href="http://github.com/videojs/video.js" class="button white" target="_blank"><i class="fa fa-github-alt"></i> Source</a></li>
+    <li><a href="https://github.com/videojs/video.js" class="button white" target="_blank"><i class="fa fa-github-alt"></i> Source</a></li>
   </ul>
 </footer>

--- a/_harp/_ga.ejs
+++ b/_harp/_ga.ejs
@@ -5,7 +5,7 @@
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'https://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>

--- a/_harp/_nav.ejs
+++ b/_harp/_nav.ejs
@@ -10,7 +10,7 @@
       <li><a href="/getting-started/">start</a></li>
       <li><a href="/getting-started/#customize">customize</a></li>
       <li><a href="http://docs.videojs.com">docs</a></li>
-                                    <li><a href="http://blog.videojs.com">blog</a></li>
+      <li><a href="http://blog.videojs.com">blog</a></li>
     </ul>
   </div>
 

--- a/_harp/_users.ejs
+++ b/_harp/_users.ejs
@@ -1,7 +1,7 @@
 <ul>
-  <li><a href="http://instagram.com" target="_blank"><img src="/img/company-logos/instagram.png" alt="Instagram"></a></li>
-  <li><a href="http://twitter.com" target="_blank"><img src="/img/company-logos/twitter.png" alt="Twitter"></a></li>
-  <li><a href="http://microsoft.com" target="_blank"><img src="/img/company-logos/microsoft.png" alt="Microsoft"></a></li>
-  <li><a href="http://dropbox.com" target="_blank"><img src="/img/company-logos/dropbox.png" alt="Dropbox"></a></li>
-  <li><a href="http://github.com" target="_blank"><img src="/img/company-logos/github.png" alt="Github"></a></li>
+  <li><a href="https://instagram.com" target="_blank"><img src="/img/company-logos/instagram.png" alt="Instagram"></a></li>
+  <li><a href="https://twitter.com" target="_blank"><img src="/img/company-logos/twitter.png" alt="Twitter"></a></li>
+  <li><a href="https://microsoft.com" target="_blank"><img src="/img/company-logos/microsoft.png" alt="Microsoft"></a></li>
+  <li><a href="https://dropbox.com" target="_blank"><img src="/img/company-logos/dropbox.png" alt="Dropbox"></a></li>
+  <li><a href="https://github.com" target="_blank"><img src="/img/company-logos/github.png" alt="Github"></a></li>
 </ul>

--- a/_harp/getting-started/index.ejs
+++ b/_harp/getting-started/index.ejs
@@ -64,38 +64,38 @@
 
       <h3 id="download-cdn">Video.js CDN</h3>
       <p>
-        Our friends at <a href="http://fastly.com" target="_blank">Fastly</a> are nice enough to provide
+        Our friends at <a href="https://fastly.com" target="_blank">Fastly</a> are nice enough to provide
         hosting for all the necessary files for Video.js on their content delivery network. Using these
         hosted files is probably the easiest way to get started using Video.js, you simply need to include
         the following links in your page.
 
       <pre><code class="html">&lt;head&gt;
-  &lt;link href="http://vjs.zencdn.net/<span class="vjs-version">vjs-version</span>/video-js.css" rel="stylesheet"&gt;
+  &lt;link href="https://vjs.zencdn.net/<span class="vjs-version">vjs-version</span>/video-js.css" rel="stylesheet"&gt;
 
   &lt;!-- If you'd like to support IE8 --&gt;
-  &lt;script src="http://vjs.zencdn.net/ie8/<span class="ie8-version">ie8-version</span>/videojs-ie8.min.js"&gt;&lt;/script&gt;
+  &lt;script src="https://vjs.zencdn.net/ie8/<span class="ie8-version">ie8-version</span>/videojs-ie8.min.js"&gt;&lt;/script&gt;
 &lt;/head&gt;
 
 &lt;body&gt;
   &lt;video id="my-video" class="video-js" controls preload="auto" width="640" height="264"
   poster="MY_VIDEO_POSTER.jpg" data-setup="{}"&gt;
-    &lt;source src="MY_VIDEO.mp4" type='video/mp4'&gt;
-    &lt;source src="MY_VIDEO.webm" type='video/webm'&gt;
+    &lt;source src="MY_VIDEO.mp4" type="video/mp4"&gt;
+    &lt;source src="MY_VIDEO.webm" type="video/webm"&gt;
     &lt;p class="vjs-no-js">
       To view this video please enable JavaScript, and consider upgrading to a web browser that
-      &lt;a href="http://videojs.com/html5-video-support/" target="_blank"&gt;supports HTML5 video&lt;/a&gt;
+      &lt;a href="https://videojs.com/html5-video-support/" target="_blank"&gt;supports HTML5 video&lt;/a&gt;
     &lt;/p&gt;
   &lt;/video&gt;
 
-  &lt;script src="http://vjs.zencdn.net/<span class="vjs-version">vjs-version</span>/video.js"&gt;&lt;/script&gt;
+  &lt;script src="https://vjs.zencdn.net/<span class="vjs-version">vjs-version</span>/video.js"&gt;&lt;/script&gt;
 &lt;/body&gt;</code></pre>
 
       <h3 id="download-npm">Install via npm</h3>
-      <p>For more advanced workflows, installing via <a href="http://npmjs.com">npm</a> is recommended</p>
+      <p>For more advanced workflows, installing via <a href="https://npmjs.com">npm</a> is recommended</p>
       <pre><code>$ npm install --save-dev video.js</code></pre>
 
       <h3 id="download-bower">Install via Bower</h3>
-      <p>Video.js is also available on <a href="http://bower.io">Bower.io</a>.</p>
+      <p>Video.js is also available on <a href="https://bower.io">Bower.io</a>.</p>
       <pre><code>$ bower install video.js</code></pre>
 
     </section>
@@ -217,7 +217,7 @@ $ git pull upstream master</code></pre>
 
       <h4>For development</h4>
       <p>
-        In order to use ES6 features, we need to transpile the source code using <a href="http://babeljs.io/" target="_blank">Babel</a>. This
+        In order to use ES6 features, we need to transpile the source code using <a href="https://babeljs.io/" target="_blank">Babel</a>. This
         means that during development we have to watch the source for changes so we can rebuild when testing.
       </p>
       <pre><code>$ grunt dev</code></pre>
@@ -240,7 +240,7 @@ $ git pull upstream master</code></pre>
       <p>Skin changes can be as simple as centering the play button (you can just add the 'vjs-big-play-centered' class to your video tag), or as complex as creating entirely new layouts. We've built a codepen project where you can explore different changes.</p>
 
 
-      <p><a href="http://codepen.io/heff/pen/EarCt" target="_blank">Video.js Skin Designer</a></p>
+      <p><a href="https://codepen.io/heff/pen/EarCt" target="_blank">Video.js Skin Designer</a></p>
 
       <p>And if you know CSS, you can always just open your Chrome dev tools and hack away!</p>
 

--- a/_harp/html5-video-support/index.ejs
+++ b/_harp/html5-video-support/index.ejs
@@ -20,24 +20,24 @@
     <tr>
       <td>
         <ul>
-          <li><a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 21+"></a></li>
+          <li><a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 21+"></a></li>
           <li><a href="https://www.apple.com/safari/" target="_blank"><img src="/img/browser-icons/safari.png" alt="Safari" title="Safari 3+"></a></li>
           <li><a href="https://www.google.com/intl/en/chrome/browser/" target="_blank"><img src="/img/browser-icons/chrome.png" alt="Chrome" title="Chrome 3+"></a></li>
-          <li><a href="http://windows.microsoft.com/en-us/internet-explorer/download-ie" target="_blank"><img src="/img/browser-icons/ie.png" alt="IE" title="IE 9+"></a></li>
+          <li><a href="https://windows.microsoft.com/en-us/internet-explorer/download-ie" target="_blank"><img src="/img/browser-icons/ie.png" alt="IE" title="IE 9+"></a></li>
         </ul>
       </td>
       <td>
         <ul>
-          <li><a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 4+"></a></li>
+          <li><a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 4+"></a></li>
           <li><a href="https://www.google.com/intl/en/chrome/browser/" target="_blank"><img src="/img/browser-icons/chrome.png" alt="Chrome" title="Chrome 6+"></a></li>
-          <li><a href="http://www.opera.com/" target="_blank"><img src="/img/browser-icons/opera.png" alt="Opera" title="Opera 10.6+"></a></li>
+          <li><a href="https://www.opera.com/" target="_blank"><img src="/img/browser-icons/opera.png" alt="Opera" title="Opera 10.6+"></a></li>
         </ul>
       </td>
       <td>
         <ul>
-          <li><a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 3.5+"></a></li>
+          <li><a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank"><img src="/img/browser-icons/firefox.png" alt="Firefox" title="Firefox 3.5+"></a></li>
           <li><a href="https://www.google.com/intl/en/chrome/browser/" target="_blank"><img src="/img/browser-icons/chrome.png" alt="Chrome" title="Chrome 3+"></a></li>
-          <li><a href="http://www.opera.com/" target="_blank"><img src="/img/browser-icons/opera.png" alt="Opera" title="Opera 10.5+"></a></li>
+          <li><a href="https://www.opera.com/" target="_blank"><img src="/img/browser-icons/opera.png" alt="Opera" title="Opera 10.5+"></a></li>
         </ul>
       </td>
     </tr>

--- a/_harp/index.ejs
+++ b/_harp/index.ejs
@@ -1,8 +1,8 @@
 <section class="main-preview-player">
-  <video id="preview-player" class="video-js vjs-fluid placeholder" controls preload="auto" poster="http://vjs.zencdn.net/v/oceans.png">
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
+  <video id="preview-player" class="video-js vjs-fluid placeholder" controls preload="auto" poster="https://vjs.zencdn.net/v/oceans.png">
+    <source src="https://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
+    <source src="https://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
+    <source src="https://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
 
@@ -64,14 +64,14 @@
       <div class="gallery-item-wrapper funnyordie">
         <iframe temp-src="//www.funnyordie.com/embed/25c17d6eb2" width="640" height="400" frameborder="0" scrolling="no" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>
       </div>
-      <a href="http://funnyordie.com" target="_blank"><img src="/img/company-logos/funnyordie.png" alt="Funny or Die"></a>
+      <a href="https://funnyordie.com" target="_blank"><img src="/img/company-logos/funnyordie.png" alt="Funny or Die"></a>
     </div>
 
     <div class="gallery-item">
       <div class="gallery-item-wrapper theguardian">
         <iframe temp-src="//embed.theguardian.com/embed/video/news/video/2015/jul/20/california-drought-eat-beef-wash-video" scrolling="no" frameborder="0" allowfullscreen></iframe>
       </div>
-      <a href="http://www.theguardian.com/video" target="_blank"><img src="/img/company-logos/guardian.png" alt="The Guardian"></a>
+      <a href="https://www.theguardian.com/video" target="_blank"><img src="/img/company-logos/guardian.png" alt="The Guardian"></a>
     </div>
   </div>
 

--- a/_harp/mimes.html
+++ b/_harp/mimes.html
@@ -2,7 +2,7 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <title>canPlayType Tests</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
   </head>
   <body id="" onload="">
     <table id="test" border="0" cellspacing="5" cellpadding="5"></table>


### PR DESCRIPTION
When I've tried using the hosted CDN links from the video.js site with my work, I've noticed that they failed to load.  On further look with inspect elements, the console tells me that it was auto blocked as I was using a secure connection with my site, but the script and CSS wasn't secure.  A simple fix with by changing it to HTTPS resolves this and it loads properly.  This fixes this the sample, along with a bunch of other links that still use HTTP.

It also replaces the single quotes in the sample with double quotes, as I've had had trouble with single quotes and keeps HTML attributes consistent, as shown on my old [pull request](https://github.com/videojs/video.js/pull/2946) that was merged.
