### PR TITLE
fix: always make requests to unpkg over HTTPS

### DIFF
--- a/_src-js/lib/vjs-version.js
+++ b/_src-js/lib/vjs-version.js
@@ -1,6 +1,7 @@
 import http from 'http';
 
 let pkgUrl = {
+  protocol: 'https',
   host: 'unpkg.com',
   path: '/video.js@latest/package.json'
 };


### PR DESCRIPTION
We were making the requests against HTTP which returned a 301 redirect
to the HTTPS protocol. However, this didn't include CORS headers, so,
everything broke. I opened an issue with unpkg but it may not be
possible to fix, so, we should just use HTTPS.

See: https://github.com/unpkg/unpkg.com/issues/22.