### PR TITLE
fix for .affixed-sidebar

### DIFF
--- a/_harp/css/components/_affixed-sidebar.scss
+++ b/_harp/css/components/_affixed-sidebar.scss
@@ -4,6 +4,7 @@
 }
 
 .affixed-sidebar {
+  position: relative;
   font-size: 1.4em;
   margin-top: 40px;
   padding: 30px;


### PR DESCRIPTION
This will prevent the nav bar from being overlapped by the pages content if the width is smaller than the content of said page. 

Issue:
https://videojs.slack.com/files/kreynolds/F6CVC2G3Y/screen_shot_2017-07-21_at_2.12.20_pm.png

