### PR TITLE
update Mux integration

### DIFF
--- a/_harp/_data.json
+++ b/_harp/_data.json
@@ -5,7 +5,7 @@
     "description": "Video.js is a JavaScript and CSS library that makes it easier to work with and build on HTML5 video. This is also known as an HTML5 Video Player.",
     "javascripts": [
       "//vjs.zencdn.net/6-unsafe/video.js",
-      "https://mux-sdks-test.s3.amazonaws.com/videojs/0/videojs-mux.js",
+      "//src.litix.io/videojs/2/videojs-mux.js",
       "/js/home.js"
     ]
   }

--- a/_harp/advanced/_data.json
+++ b/_harp/advanced/_data.json
@@ -4,7 +4,7 @@
     "description": "Video.js is a JavaScript and CSS library that makes it easier to work with and build on HTML5 video. This is also known as an HTML5 Video Player.",
     "javascripts": [
       "//vjs.zencdn.net/6-unsafe/video.js",
-      "https://mux-sdks-test.s3.amazonaws.com/videojs/0/videojs-mux.js",
+      "//src.litix.io/videojs/2/videojs-mux.js",
       "/js/advanced.js"
     ],
     "styles": [


### PR DESCRIPTION
We had previously locked videojs.com on a test version of the Mux integration for an extended test, and this change puts it back on the mainline release of [videojs-mux](https://docs.mux.com/docs/web-integration-guide?muxLang=Video.js).