### PR TITLE
move mux plugin to ready()

### DIFF
--- a/_src-js/advanced.js
+++ b/_src-js/advanced.js
@@ -15,13 +15,14 @@ if (typeof Uint8Array !== 'undefined') {
 }
 
 const player = window.player = videojs('preview-player', {
-  fluid: true,
-  plugins: {
-    mux: {
+  fluid: true
+}, function() {
+  if (player.hasPlugin('mux')) {
+    player.mux({
       data: {
         property_key: 'VJSISBEST',
       }
-    }
+    });
   }
 });
 

--- a/_src-js/home.js
+++ b/_src-js/home.js
@@ -4,19 +4,17 @@ import $ from 'jquery';
 import videojs from 'video.js';
 
 const player = window.player = videojs('preview-player', {
-  fluid: true,
-  plugins: {
-    mux: {
+  fluid: true
+}, function() {
+  if (player.hasPlugin('mux')) {
+    player.mux({
       data: {
         property_key: 'VJSISBEST',
         video_title: 'Disney\'s Oceans',
         video_id: 1
       }
-    }
-  }
-});
-
-player.on('ready', function() {
+    })
+  };
   player.removeClass('placeholder');
 });
 


### PR DESCRIPTION
litix.io is in the EasyPrivacy list. Where an ad blocker has blocked the mux plugin script, the player fails to initialise as the plugin defined in the player opts is not available. This moves mux initialisation to the ready callback and checks for its existence.