### PR TITLE
Support fragment identifier (e.g. #elephantsdream) in the URL of the Advanced page to specify a particular video from the playlist

### DIFF
--- a/_src-js/advanced.js
+++ b/_src-js/advanced.js
@@ -3,6 +3,7 @@ import 'es6-shim';
 import 'es7-shim';
 import videojs from 'video.js';
 import document from 'global/document';
+import window from 'global/window';
 import 'videojs-playlist';
 import 'videojs-playlist-ui';
 import playlist from './lib/playlist.js';
@@ -30,14 +31,25 @@ player.on('loadstart', function() {
   const pl = player.playlist();
   const plitem = pl[player.playlist.currentItem()];
 
+  window.location.hash = plitem.id;
+
   player.mux.emit('videochange', {
-    video_id: plitem.name,
+    video_id: plitem.id,
     video_title: plitem.name,
     video_duration: plitem.duration,
   });
 });
 
 player.playlist(playlist);
+
+const hash = window.location.hash.substr(1);
+if ( hash ) {
+  const hashItem = playlist.findIndex(function(item) { return item.id == hash; });
+  if ( hashItem != -1 ) {
+    player.playlist.currentItem(hashItem);
+  }
+}
+
 player.playlistUi();
 
 boundProperties(player);

--- a/_src-js/lib/playlist.js
+++ b/_src-js/lib/playlist.js
@@ -10,6 +10,7 @@ export default [{
     'fugiat nulla pariatur. Excepteur sint occaecat cupidatat non ' +
     'proident, sunt in culpa qui officia deserunt mollit anim id est ' +
     'laborum.',
+    id: 'disneys-oceans',
   duration: 45,
   sources: [
     { src: '//vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
@@ -30,6 +31,7 @@ export default [{
 }, {
   name: 'Sintel',
   description: 'The film follows a girl named Sintel who is searching for a baby dragon she calls Scales.',
+  id: 'sintel',
   sources: [
     { src: '//d2zihajmogu5jn.cloudfront.net/sintel/master.m3u8', type: 'application/x-mpegurl' },
     { src: '//d2zihajmogu5jn.cloudfront.net/sintel/sintel.mp4', type: 'video/mp4' },
@@ -49,6 +51,7 @@ export default [{
 }, {
   name: 'Advanced Bip Bop',
   description: "Apple's test HLS stream",
+  id: 'bipbop-advanced',
   sources: [
     {
       src: '//d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
@@ -58,6 +61,7 @@ export default [{
 }, {
   name: "Elephant's Dream",
   description: 'The film features two men, Proog, who is older and more experienced, and Emo, who is young and nervous, living in a miraculous construction referred to only as "The Machine".',
+  id: 'elephantsdream',
   sources: [
     { src: '//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4', type: 'video/mp4' },
     { src: '//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.ogg', type: 'video/ogg' }
@@ -121,6 +125,7 @@ export default [{
   ]
 }, {
   name: 'Tears of Steel',
+  id: 'tears-of-steel',
   sources: [
     { src: '//d2zihajmogu5jn.cloudfront.net/tears-of-steel/playlist.m3u8', type: 'application/x-mpegurl' },
     { src: '//d2zihajmogu5jn.cloudfront.net/tears-of-steel/tears_of_steel_720p.mp4', type: 'video/mp4' }
@@ -140,6 +145,7 @@ export default [{
 }, {
   name: 'Big Buck Bunny',
   description: 'The plot follows a day of the life of Big Buck Bunny when he meets three bullying rodents, Frank (the leader of the rodents), Rinky and Gimera.',
+  id: 'big-buck-bunny',
   sources: [
     { src: '//d2zihajmogu5jn.cloudfront.net/big-buck-bunny/master.m3u8', type: 'application/x-mpegurl' },
     { src: '//d2zihajmogu5jn.cloudfront.net/big-buck-bunny/bbb.mp4', type: 'video/mp4' },


### PR DESCRIPTION
Allow URLs with fragment identifiers to specify a particular video (e.g. https://videojs.com/advanced/#elephantsdream), so that specific videos can be bookmarked.

This PR allows fragment identifiers to be specified, and also adds the fragment identifier for the video currently being played to the URL in the browser, so that users can tell what the correct identifier for each video is.