### PR TITLE
Add a text alternative for the npm shield image

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
         src: ['_harp/js/index.js']
       },
       html: {
-        src: ['_www/getting-started/index.html']
+        src: ['_www/index.html', '_www/getting-started/index.html']
       }
     }
   });

--- a/_harp/css/modules/_utility.scss
+++ b/_harp/css/modules/_utility.scss
@@ -35,3 +35,16 @@
 @function grayscale($value) {
   @return #{ "grayscale(" + $value + ")" };
 }
+
+.offscreen {
+  position: absolute!important;
+  clip: rect(1px 1px 1px 1px)!important;
+  clip: rect(1px, 1px, 1px, 1px)!important;
+  clip-path: inset(50%)!important;
+  padding: 0!important;
+  border: 0!important;
+  height: 1px!important;
+  width: 1px!important;
+  overflow: hidden!important;
+  white-space: nowrap!important;
+}

--- a/_harp/index.ejs
+++ b/_harp/index.ejs
@@ -11,7 +11,8 @@
       <img src="/img/logo.png" alt="Video.js" class="logo">
       <span class="subhead">The Player Framework</span>
       <a href="https://www.npmjs.com/package/video.js">
-        <img src="https://img.shields.io/npm/v/video.js.svg" class="npm-badge">
+        <!-- Note that this alt text eventually needs updating to reflect the same version information that is shown in the shields.io image -->
+        <img src="https://img.shields.io/npm/v/video.js.svg" class="npm-badge" alt="Video.js on npm">
       </a>
     </div>
   </div>

--- a/_harp/index.ejs
+++ b/_harp/index.ejs
@@ -11,8 +11,8 @@
       <img src="/img/logo.png" alt="Video.js" class="logo">
       <span class="subhead">The Player Framework</span>
       <a href="https://www.npmjs.com/package/video.js">
-        <!-- Note that this alt text eventually needs updating to reflect the same version information that is shown in the shields.io image -->
-        <img src="https://img.shields.io/npm/v/video.js.svg" class="npm-badge" alt="Video.js on npm">
+        <span class="offscreen">Video.js on npm: version <span class="vjs-version">$LATEST_VERSION$</span></span>
+        <img src="https://img.shields.io/npm/v/video.js.svg" class="npm-badge" alt="">
       </a>
     </div>
   </div>

--- a/_src-js/home.js
+++ b/_src-js/home.js
@@ -2,6 +2,7 @@ import window from 'global/window';
 import document from 'global/document';
 import $ from 'jquery';
 import videojs from 'video.js';
+import { getPackage } from './lib/vjs-version.js';
 
 const player = window.player = videojs('preview-player', {
   fluid: true
@@ -24,6 +25,13 @@ player.on(['play', 'playing'], function() {
 });
 player.on(['pause'], function() {
   overlay.removeClass('transparent');
+});
+
+// Get the package information for setting the version on the NPM shield/badge
+getPackage(function(e, pkg) {
+  if (e) console.error(e);
+
+  $('.vjs-version').text(pkg.version);
 });
 
 // Poor man's lazy loading the iframe content to speed up homeage loading

--- a/_src-js/lib/playlist.js
+++ b/_src-js/lib/playlist.js
@@ -127,4 +127,3 @@ export default [{
     }
   ]
 }];
-


### PR DESCRIPTION
Temporary fix to add alt text to the npm shield image. As noted, the alt text eventually needs updating to reflect the same version information that is shown in the shields.io image.