### PR TITLE
Mobile Safari bugfix: add playsInline attribute to home hero and advanced example

### DIFF
--- a/src/components/HomeComponents/AdvancedExample/index.jsx
+++ b/src/components/HomeComponents/AdvancedExample/index.jsx
@@ -190,6 +190,7 @@ class AdvancedExample extends React.Component {
                   preload="auto"
                   crossOrigin="anonymous"
                   className="video-js vjs-fluid vjs-big-play-centered"
+                  playsInline
                 />
                 <PlayerPlaylist />
               </VideoWrapper>

--- a/src/components/HomeComponents/Hero.jsx
+++ b/src/components/HomeComponents/Hero.jsx
@@ -116,6 +116,7 @@ const HomeHero = props => (
             ]}
             poster={props.heroTheme.poster}
             onPlay={props.onPlay}
+            playsInline
           />
         ) : (
           <PlayerPlaceholder />

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -51,6 +51,7 @@ class Player extends React.Component {
           <video
             ref={node => (this.videoNode = node)}
             className="video-js vjs-16-9"
+            playsInline={this.props.playsInline}
           />
         </div>
       </div>


### PR DESCRIPTION
Bug:

1. Open homepage on mobile safari
1. Play the video in the hero image
1. Safari's native full-screen video player pops out (expected)
1. Close Safari's native full-screen video player by tapping the "x" in the top left corner
1. Page is bugged out - video player is black, buttons under the video player disappear

FIx:

* add playsInline attribute to the `video` component in hero image
* also add playsInline attribute to the `video` component in the advanced example

There might be more videos that I missed that we want to add the attribute to but I think these are the only ones

---

See if you can repro this on production and then try my fix on the [deploy preview](https://deploy-preview-109--videojs-dot-com.netlify.com/)