### PR TITLE
Sync guides with changes made in the main video.js repository since moving them here

### DIFF
--- a/src/mdx-pages/guides/components.mdx
+++ b/src/mdx-pages/guides/components.mdx
@@ -48,9 +48,10 @@ console.log(button.el());
 The above code will output
 
 ```html
-<div class="video-js">
-  <div class="vjs-button">Button</div>
-</div>
+<button class="vjs-control vjs-button" type="button" aria-disabled="false">
+  <span class="vjs-icon-placeholder" aria-hidden="true"></span>
+  <span class="vjs-control-text" aria-live="polite"></span>
+</button>
 ```
 
 Adding the new button to the player
@@ -62,6 +63,30 @@ var button = player.addChild('button');
 
 console.log(button.el());
 // will have the same html result as the previous example
+```
+
+The text of the button can be set as an option:
+
+```js
+const myButton = player.addChild('button', {controlText: 'abc'});
+```
+
+or set later:
+
+```js
+myButton.controlText('def');
+```
+
+The control text of a button is normally not visible (but present for screen readers) as the default buttons all display only an icon. The text can be displayed by adding a `vjs-text-visible` class to the button. This or any other class may be set as a setup option, or later by API.
+
+```js
+const myButton = player.addChild('button', {className: 'vjs-text-visible'});
+```
+
+or set later:
+
+```js
+myButton.addClass('vjs-text-visible');
 ```
 
 ## Component Children

--- a/src/mdx-pages/guides/faqs.mdx
+++ b/src/mdx-pages/guides/faqs.mdx
@@ -235,6 +235,18 @@ Yes! See the [Webpack and Video.js configuration guide][webpack-guide].
 
 Yes! See [ReactJS integration example][react-guide].
 
+## Q: Can the big play button be centered?
+
+The default skin offsets the button to not obscure the poster image, but just add a `vjs-big-play-centered` class to the player to have it centred.
+
+## Q: Can the big play button be shown when paused?
+
+Add a `vjs-show-big-play-button-on-pause` class to the player to display the button when paused.
+
+## Q: Why is the picture-in-picture button different in Firefox?
+
+Firefox does not support the HTML video Picture-in-Picture (PIP) API, so it is not possible to have a custom button in the Video.js controls. Firefox has its own overlay PIP button, and its [own logic for whether to display it][firefox-pip].
+
 [ads]: https://github.com/videojs/videojs-contrib-ads
 
 [audio-tracks]: /guides/audio-tracks
@@ -254,6 +266,8 @@ Yes! See [ReactJS integration example][react-guide].
 [debug-guide]: /guides/debugging
 
 [eme]: https://github.com/videojs/videojs-contrib-eme
+
+[firefox-pip]: https://firefox-source-docs.mozilla.org/toolkit/components/pictureinpicture/pictureinpicture/index.html#the-picture-in-picture-toggle
 
 [flash-eol]: https://www.adobe.com/products/flashplayer/end-of-life.html
 

--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -122,6 +122,20 @@ Puts the player in [fluid](#fluid) mode and the value is used when calculating t
 
 Alternatively, the classes `vjs-16-9`, `vjs-9-16`, `vjs-4-3` or `vjs-1-1` can be added to the player.
 
+### `audioOnlyMode`
+
+> Type: `boolean`
+> Default: `false`
+
+If set to true, it asynchronously hides all player components except the control bar, as well as any specific controls that are needed only for video. This option can be set to `true` or `false` by calling `audioOnlyMode([true|false])` at runtime. When used as a setter, it returns a Promise. When used as a getter, it returns a Boolean.
+
+### `audioPosterMode`
+
+> Type: `boolean`
+> Default: `false`
+
+If set to true, it enables the poster viewer experience by hiding the video element and displaying the poster image persistently. This option can be set to `true` or `false` by calling `audioPosterMode([true|false])` at runtime.
+
 ### `autoSetup`
 
 > Type: `boolean`

--- a/src/mdx-pages/guides/player-workflows.mdx
+++ b/src/mdx-pages/guides/player-workflows.mdx
@@ -361,6 +361,8 @@ See [ReactJS integration example](/guides/react)
 
 ### Angular
 
+See [Angular integration example](/docs/guides/angular.md)
+
 ### Vue
 
 See [Vue integration example](/guides/vue)


### PR DESCRIPTION
This brings in changes from the following PRs:

- https://github.com/videojs/video.js/pull/7635
- https://github.com/videojs/video.js/pull/7609
- https://github.com/videojs/video.js/pull/7629
- https://github.com/videojs/video.js/pull/7647
- https://github.com/videojs/video.js/pull/7611

This captures all changes to `docs/guides/` in Video.js since they were initially imported into this repository.

There is a related PR here: https://github.com/videojs/video.js/pull/7706