### PR TITLE
chore: Update nvmrc to lts/erbium

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium


### PR DESCRIPTION
Update `.nvmrc` file to use `lts/erbium` (node v12).