### PR TITLE
fix: Update Advanced Example page hero

### DIFF
--- a/src/components/AdvancedComponents/AdvancedHero.jsx
+++ b/src/components/AdvancedComponents/AdvancedHero.jsx
@@ -3,37 +3,75 @@ import styled from 'styled-components';
 
 import Hero from '../../components/Hero';
 import Container from '../../components/Container';
-import { H1, H2 } from '../../components/Typography';
+import { H2 } from '../../components/Typography';
 import { theme } from '../../utils/styles';
 
-const StyledH2 = styled(H2)`
-  letter-spacing: -0.01em;
-  font-size: 24px;
-  line-height: 1.5;
-  max-width: 33em;
-  margin: 0 auto;
-`;
-
 const StyledHero = styled(Hero)`
+  ${Container} {
+    padding-bottom: 2.5em;
+  }
+  ${({ theme }) => theme.media.medium`
+    ${Container} {
+      padding-bottom: 3.5em;
+    }
+  `}
+  ${({ theme }) => theme.media.large`
+    ${Container} {
+      padding-bottom: 6em;
+    }
+  `}
   ${({ theme }) => theme.media.xlLarge`
-    background-position: center -520px;
-
+    background-position: center -425px;
     ${Container} {
       padding-top: 10em;
-      padding-bottom: 10em;
+      padding-bottom: 13em;
     }
+  `}
+`;
+
+const StyledH2 = styled(H2)`
+  font-size: 34px;
+  line-height: 1em;
+  margin-bottom: 1.5em;
+  font-weight: 500;
+  ${({ theme }) => theme.media.medium`
+    font-size: 56px;
+    margin-bottom: 1.1em;
+    padding: 0;
+  `}
+  ${({ theme }) => theme.media.medLarge`
+    font-size: 56px;
+    margin-bottom: 0.3em;
+    padding: 0;
+  `}
+`;
+
+const Subheading = styled.p`
+  font-size: 20px;
+  line-height: 1.4em;
+  font-weight: 100;
+  max-width: 33em;
+  margin: 0 auto;
+  text-align: center;
+  color: #fff;
+  padding: 0 1em;
+  ${({ theme }) => theme.media.small`
+    font-size: 22px;
+  `}
+  ${({ theme }) => theme.media.medLarge`
+    padding: 0;
   `}
 `;
 
 const AdvancedHero = () => (
   <StyledHero theme={{ ...theme, currentTheme: theme.city }}>
     <Container>
-      <H1>Advanced Example</H1>
-      <StyledH2>
+      <StyledH2>Advanced Example</StyledH2>
+      <Subheading>
         The advanced example includes the playlist plugin, along with some
         useful details such as what all of the player properties are, and what
         events have fired and how often.
-      </StyledH2>
+      </Subheading>
     </Container>
   </StyledHero>
 );


### PR DESCRIPTION
The Advanced Example page hero component was missed in the recent tag/style updates for [PR 136](https://github.com/videojs/videojs.com/pull/136) and this change corrects that omission.

**Changes include:**

- Remove the `h1` tag from the Hero component and update the headings/subheadings to use `h2` and `p` tags for accessibility.
- Style is standardized to match other Hero components with subheadings on the site.