### PR TITLE
fix: Fix back navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1049,15 +1049,14 @@
       }
     },
     "@reach/router": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",
-      "integrity": "sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
+      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
       "requires": {
-        "create-react-context": "^0.2.1",
+        "create-react-context": "0.3.0",
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "warning": "^3.0.0"
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "@sindresorhus/is": {
@@ -3823,31 +3822,20 @@
       }
     },
     "create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
       "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
       },
       "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "fbjs": {
-          "version": "0.8.17",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
+            "loose-envify": "^1.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.0.21",
     "@mdx-js/react": "^1.0.21",
+    "@reach/router": "^1.3.4",
     "@videojs/themes": "^1.0",
     "babel-plugin-styled-components": "^1.10.0",
     "gatsby": "^2.4.3",


### PR DESCRIPTION
Fixes back navigation going to /.

This was [fixed in gatsby 2.19.5](https://github.com/gatsbyjs/gatsby/issues/8357#issuecomment-584551111) by upgrading its dependency @reach/router. Updating gatsby to that version isn't trivial, and the effort would probably be better spent on updating the major version, so as a quick fix this jsut updates @reach/router. 