### PR TITLE
fix: fix version in getting started

### DIFF
--- a/src/components/GettingStartedComponents/GettingStartedArticle.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedArticle.jsx
@@ -34,7 +34,7 @@ const Wrapper = styled.article`
 const GettingStartedArticle = ({ mdxData }) => (
   <Wrapper>
     <WithMdxComponents contentSlug={mdxData.fields.slug}>
-      <MDXRenderer>{mdxData.body.replace(/\$\{VJS_VERSION\}/g, version)}</MDXRenderer>
+      <MDXRenderer>{mdxData.body.replace(/\$\{VJS_VERSION\}/g, version.version)}</MDXRenderer>
     </WithMdxComponents>
   </Wrapper>
 );


### PR DESCRIPTION
Importing the version JSON differently in #148 to remove a deprecation warning (`Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)`) broke the version number replacement in getting started.

