### PR TITLE
feat: Optimise the SEO

### DIFF
--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -52,7 +52,7 @@ function Seo({ description, lang, meta, keywords, title, ...props }) {
         },
         {
           property: `og:title`,
-          content: title,
+          content: `${title}${title.includes('Video.js') ? '' : ' | Video.js'}`,
         },
         {
           property: `og:description`,
@@ -72,7 +72,7 @@ function Seo({ description, lang, meta, keywords, title, ...props }) {
         },
         {
           name: `twitter:title`,
-          content: title,
+          content: `${title}${title.includes('Video.js') ? '' : ' | Video.js'}`,
         },
         {
           name: `twitter:description`,

--- a/src/mdx-pages/guides/angular.mdx
+++ b/src/mdx-pages/guides/angular.mdx
@@ -1,6 +1,7 @@
 ---
 title: Angular and Video.js
 category: integrations
+description: A brief guide to using Video.js with Angular.
 ---
 
 This is a basic Angular and Video.js player implementation. This example component instantiates the player on `OnInit` and destroys it on `OnDestroy`:

--- a/src/mdx-pages/guides/audio-tracks.mdx
+++ b/src/mdx-pages/guides/audio-tracks.mdx
@@ -2,6 +2,7 @@
 title: Audio Tracks
 category: tracks
 order: 2
+description: How to use audio tracks with Video.js 
 ---
 
 Audio tracks are a feature of HTML5 video for providing alternate audio track selections

--- a/src/mdx-pages/guides/components.mdx
+++ b/src/mdx-pages/guides/components.mdx
@@ -2,6 +2,7 @@
 title: Components
 category: advanced
 order: 3
+description: Understanding components, the building blocks of the Video.js player.
 ---
 
 The architecture of the Video.js player is centered around components. The `Player` class and all classes representing player controls and other UI elements inherit from the `Component` class. This architecture makes it easy to construct the user interface of the Video.js player in a tree-like structure that mirrors the DOM.

--- a/src/mdx-pages/guides/debugging.mdx
+++ b/src/mdx-pages/guides/debugging.mdx
@@ -2,6 +2,7 @@
 title: Debugging
 category: advanced
 order: 1
+description: A guide to using Video.js's logging capabilities.
 ---
 
 ## Logging

--- a/src/mdx-pages/guides/embeds.mdx
+++ b/src/mdx-pages/guides/embeds.mdx
@@ -2,6 +2,7 @@
 title: Embed a Video.js Player
 category: basics
 order: 1
+description: Explaining the ways to embed a Video.js player.
 ---
 
 Video.js is meant to be an enhancement to the video element in HTML5 and for years, its embed code has been just a `<video>` element.

--- a/src/mdx-pages/guides/event-target.mdx
+++ b/src/mdx-pages/guides/event-target.mdx
@@ -2,6 +2,7 @@
 title: Event Target
 category: advanced
 order: 4
+description: The event system in Video.js
 ---
 
 ## Overview

--- a/src/mdx-pages/guides/faqs.mdx
+++ b/src/mdx-pages/guides/faqs.mdx
@@ -2,6 +2,7 @@
 title: FAQs
 category: basics
 order: 4
+description: Some frequently asked questions about Video.js
 ---
 
 ## Q: What is Video.js?

--- a/src/mdx-pages/guides/hooks.mdx
+++ b/src/mdx-pages/guides/hooks.mdx
@@ -2,6 +2,7 @@
 title: Hooks
 category: advanced
 order: 6
+description: Hooks, a feature of Video.js for advanced player configuration workflows
 ---
 
 Hooks exist so that users can globally hook into certain Video.js lifecycle moments.

--- a/src/mdx-pages/guides/languages.mdx
+++ b/src/mdx-pages/guides/languages.mdx
@@ -2,6 +2,7 @@
 title: Languages
 category: general
 order: 5
+description: Video.js's localization functionality explained.
 ---
 
 Video.js includes localization support to present text in a language other than the default English where appropriate.

--- a/src/mdx-pages/guides/layout.mdx
+++ b/src/mdx-pages/guides/layout.mdx
@@ -2,6 +2,7 @@
 title: Layout
 category: general
 order: 4
+description: Layout and repsonsiveness options for Video.js players.
 ---
 
 Video.js generally lays out the player to the dimensions that are set as attributes or via CSS, like other DOM elements. However, we provide a few ways to make the player be more fluid.

--- a/src/mdx-pages/guides/live.mdx
+++ b/src/mdx-pages/guides/live.mdx
@@ -2,6 +2,7 @@
 title: Live Support
 category: general
 order: 6
+description: Live streaming with Video.js.
 ---
 
 > Note the "old" live user interface is currently the default, see the section on [the new user interface](#the-new-user-interface) for information on setting that up.

--- a/src/mdx-pages/guides/middleware.mdx
+++ b/src/mdx-pages/guides/middleware.mdx
@@ -2,6 +2,7 @@
 title: Middleware
 category: advanced
 order: 8
+description: An advanced feature of Video.js let allows you to intercept and influence how the player interacts with the playback tech.
 ---
 
 Middleware is a Video.js feature that allows interaction with and modification of how the `Player` and `Tech` talk to each other. For more in-depth information, check out our [feature spotlight](https://videojs.com/blog/feature-spotlight-middleware/).

--- a/src/mdx-pages/guides/modal-dialog.mdx
+++ b/src/mdx-pages/guides/modal-dialog.mdx
@@ -2,6 +2,7 @@
 title: Modal Dialogs
 category: advanced
 order: 5
+description: How to create and customise modal dialogs in Video.js.
 ---
 
 The `ModalDialog` component is part of Video.js core and provides a baked-in UI for full-player overlays.

--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -2,6 +2,7 @@
 title: Video.js Options Reference
 category: basics
 order: 3
+description: The standard options available when creating a Video.js player. 
 ---
 
 > **Note:** This document is only a reference for available options. To learn about passing options to Video.js, see [the setup guide](/guides/setup#options).

--- a/src/mdx-pages/guides/player-workflows.mdx
+++ b/src/mdx-pages/guides/player-workflows.mdx
@@ -2,6 +2,7 @@
 title: Player Workflows
 category: general
 order: 1
+description: Working with the Video.js player API.
 ---
 
 This document outlines many considerations for using Video.js for advanced player workflows. Be sure to read [the setup guide](/guides/setup) first!

--- a/src/mdx-pages/guides/plugins.mdx
+++ b/src/mdx-pages/guides/plugins.mdx
@@ -2,6 +2,7 @@
 title: Video.js Plugins
 category: advanced
 order: 2
+description: Video.js's plugin architecture, making it the most customizable player.
 ---
 
 One of the great strengths of Video.js is its ecosystem of plugins that allow authors from all over the world to share their video player customizations. This includes everything from the simplest UI tweaks to new [playback technologies and source handlers][tech]!

--- a/src/mdx-pages/guides/react.mdx
+++ b/src/mdx-pages/guides/react.mdx
@@ -1,6 +1,7 @@
 ---
 title: React and Video.js
 category: integrations
+description: A brief guide to using Video.js with React
 ---
 
 These are several React and Video.js player implementations and examples.

--- a/src/mdx-pages/guides/setup.mdx
+++ b/src/mdx-pages/guides/setup.mdx
@@ -2,6 +2,7 @@
 title: Video.js Setup
 category: basics
 order: 2
+description: Explaining the ways to set up a Video.js player. 
 ---
 
 ## Getting Video.js

--- a/src/mdx-pages/guides/skins.mdx
+++ b/src/mdx-pages/guides/skins.mdx
@@ -2,6 +2,7 @@
 title: Skins
 category: general
 order: 3
+description: Make your Video.js player yours by customizing the player skin.
 ---
 
 ## Default Skin

--- a/src/mdx-pages/guides/tech.mdx
+++ b/src/mdx-pages/guides/tech.mdx
@@ -2,6 +2,7 @@
 title: Playback Technology ("Tech")
 category: advanced
 order: 7
+description: Understanding Video.js's playback techs.
 ---
 
 Playback Technology refers to the specific browser or plugin technology used to play the video or audio. When using HTML5, the playback technology is the video or audio element. When using the [videojs-youtube][youtube] tech, the playback technology is the YouTube player. The tech also includes an API wrapper to translate between the Video.js controls and API to the specific playback technology used.

--- a/src/mdx-pages/guides/text-tracks.mdx
+++ b/src/mdx-pages/guides/text-tracks.mdx
@@ -2,6 +2,7 @@
 title: Text Tracks
 category: tracks
 order: 1
+description: Use captions, subitles, chapters and other text tracks with Video.js.
 ---
 
 Text tracks are a feature of HTML5 for displaying time-triggered text to the end-user. Video.js offers a cross-browser implementation of text tracks.

--- a/src/mdx-pages/guides/troubleshooting.mdx
+++ b/src/mdx-pages/guides/troubleshooting.mdx
@@ -2,6 +2,7 @@
 title: Troubleshooting
 category: general
 order: 7
+description: A guide to troubleshooting common issues with Video.js.
 ---
 
 ## Problems with media formats

--- a/src/mdx-pages/guides/video-tracks.mdx
+++ b/src/mdx-pages/guides/video-tracks.mdx
@@ -2,6 +2,7 @@
 title: Video Tracks
 category: tracks
 order: 3
+description: Video tracks with Video.js.
 ---
 
 > **Note:** While video tracks [are a standard][spec-videotrack], there are no compatible implementations at this time. This is an experimental technology!

--- a/src/mdx-pages/guides/videojs.mdx
+++ b/src/mdx-pages/guides/videojs.mdx
@@ -2,6 +2,7 @@
 title: videojs Functions
 category: general
 order: 2
+description: The top level functions of `videojs`.
 ---
 
 ## `videojs()`

--- a/src/mdx-pages/guides/vue.mdx
+++ b/src/mdx-pages/guides/vue.mdx
@@ -1,6 +1,7 @@
 ---
 title: Vue and Video.js
 category: integrations
+description: A guide to using Video.js with vue.
 ---
 
 This is a basic Vue and Video.js player implementation. This example component instantiates the player on `mounted` and destroys it on `beforeDestroy`:

--- a/src/mdx-pages/guides/webpack.mdx
+++ b/src/mdx-pages/guides/webpack.mdx
@@ -1,6 +1,7 @@
 ---
 title: Webpack and Video.js
 category: integrations
+description: Using Video.js with webpack.
 ---
 
 Video.js and official libraries and plugins all work in a Webpack-based build environment.

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -70,7 +70,7 @@ const Subheading = styled.p`
 
 const NotFoundPage = () => (
   <Layout>
-    <Seo title="Video.js - 404: Not found" />
+    <Seo title="404: Not found" description="Nothing to see here." />
     <StyledHero theme={{ ...theme, currentTheme: theme.forest }}>
       <Container>
         <StyledH2>Uh oh...Not found!</StyledH2>

--- a/src/pages/advanced.jsx
+++ b/src/pages/advanced.jsx
@@ -7,7 +7,7 @@ import AdvancedHero from '../components/AdvancedComponents/AdvancedHero';
 
 const AdvancedPage = () => (
   <Layout>
-    <Seo title="Video.js - Make your player yours" />
+    <Seo title="Advanced example" description="An extended example of Video.js player features." />
     <AdvancedHero />
     <AdvancedExample enableThemeQueryParam hideDescription />
   </Layout>

--- a/src/pages/html5-video-support.jsx
+++ b/src/pages/html5-video-support.jsx
@@ -50,7 +50,7 @@ const StyledH2 = styled(H2)`
 
 const SecondPage = () => (
   <Layout>
-    <Seo title="HTML5 Video Support" />
+    <Seo title="HTML5 Video Support" description="A table of HTML5 codec support by browser." />
     <StyledHero theme={{ ...theme, currentTheme: theme.fantasy }}>
       <Container>
         <StyledH2>HTML5 Video Support by Codec</StyledH2>

--- a/src/pages/plugins.jsx
+++ b/src/pages/plugins.jsx
@@ -8,7 +8,7 @@ import PluginsList from '../components/PluginsComponents/PluginsList';
 
 const PluginsPage = () => (
   <Layout>
-    <Seo title="plugins/index - Video.js: The Player Framework" />
+    <Seo title="Video.js Plugins" description="List of plugins for Video.js." />
     <PluginsHero />
     <PluginsList />
   </Layout>

--- a/src/templates/GuidesListTemplate.jsx
+++ b/src/templates/GuidesListTemplate.jsx
@@ -42,7 +42,7 @@ const GuidesListTemplate = ({
   });
 
   return (
-    <GuidesLayout seo={{ title: 'Video.js Guides' }}>
+    <GuidesLayout seo={{ title: 'Video.js Guides', description: 'Documentation for Video.js' }}>
       <Container>
         {categories.map(category => (
           <GuidesCategory key={shortid.generate()} category={category}></GuidesCategory>

--- a/src/templates/GuidesViewTemplate.jsx
+++ b/src/templates/GuidesViewTemplate.jsx
@@ -20,7 +20,7 @@ const BackBox = styled.div`
 const GuidesViewTemplate = ({
   data: { mdx }
 }) => (
-  <GuidesLayout seo={{ title: 'Video.js Guides' }}>
+  <GuidesLayout seo={{ title: mdx.frontmatter.title, description: mdx.frontmatter.description }}>
     <BackBox>
       <Link href="/guides">Back to Guides</Link>
     </BackBox>
@@ -39,6 +39,7 @@ export const guidesViewQuery = graphql`
       }
       frontmatter {
         title
+        description
       }
       body
     }

--- a/src/templates/HomeTemplate.jsx
+++ b/src/templates/HomeTemplate.jsx
@@ -21,6 +21,7 @@ const IndexPage = props => {
       <Seo
         title="Video.js - Make your player yours"
         keywords={['HTML5 video', 'player', 'hls', 'adaptive-bitrate']}
+        description="The world's most popular open source HTML5 player framework"
       />
       <Hero
         heroTheme={heroTheme}


### PR DESCRIPTION
Add descriptions to static pages and guides, so the description in the head isn't the same for everything.
Use the individual guide title rather than a generic title for guides.