### PR TITLE
Fix: make checkbox labels clickable

### DIFF
--- a/src/components/CheckboxInput.jsx
+++ b/src/components/CheckboxInput.jsx
@@ -54,11 +54,11 @@ const Label = styled.label`
 
 const CheckboxInput = ({ label, checked, onChange }) => (
   <Wrapper>
-    <Input readOnly value={checked} name={label} id={label} />
+    <Input readOnly type="hidden" value={checked} name={label} id={label} />
     <Box checked={checked} onClick={onChange}>
       {checked && <StyledTickIcon />}
     </Box>
-    {label && <Label htmlFor={label}>{label}</Label>}
+    {label && <Label htmlFor={label} onClick={onChange}>{label}</Label>}
   </Wrapper>
 );
 


### PR DESCRIPTION
### Done 
- Hide inputs that are currently showing when checkbox labels are clicked 
- Enable checkboxes to be updated by clicking checkbox labels.

### Before
![checkbox-before](https://user-images.githubusercontent.com/57550290/192540095-cc8a0c9d-99a5-4a0d-91ec-5b0557d1ba4d.gif)
### After 
![checkbox-after](https://user-images.githubusercontent.com/57550290/192540114-c70f3117-39ff-4370-bd3a-773048ac8f90.gif)


**Fixes** #161 