### PR TITLE
React.mdx Use correct class for centering play btn

### DIFF
--- a/src/mdx-pages/guides/react.mdx
+++ b/src/mdx-pages/guides/react.mdx
@@ -27,7 +27,7 @@ export const VideoJS = (props) => {
       // The Video.js player needs to be _inside_ the component el for React 18 Strict Mode. 
       const videoElement = document.createElement("video-js");
 
-      videoElement.className = 'videojs-big-play-centered';
+      videoElement.classList.add('vjs-big-play-centered');
       videoRef.current.appendChild(videoElement);
 
       const player = playerRef.current = videojs(videoElement, options, () => {


### PR DESCRIPTION
This PR contains some updates to the `React.mdx` documentation page:

- using the correct CSS class name in order to center the play button: `vjs-big-play-centered` instead of `videojs-big-play-centered`
- using `classList.add` instead of `className = ...`  - IMO it's the "better" way to assign a class to a DOM element as devs don't have to do direct management of the `className` attribute