### PR TITLE
docs: ES5 class extension

### DIFF
--- a/src/mdx-pages/guides/components.mdx
+++ b/src/mdx-pages/guides/components.mdx
@@ -152,6 +152,15 @@ class TitleBar extends Component {
   }
 }
 ```
+Note that due to the deprecation of the `extend()` function, to extend a component when transpiling to ES5, you will need to utilize the following syntax.
+```js
+// My ES5 constructor function extending Component
+function MyComponent(arguments) {
+  Component.call(this, arguments);
+}
+
+MyComponent.prototype = Object.create(Component.prototype);
+```
 
 Once the component is created, it can be registered, and used in a player.
 

--- a/src/mdx-pages/guides/components.mdx
+++ b/src/mdx-pages/guides/components.mdx
@@ -152,7 +152,7 @@ class TitleBar extends Component {
   }
 }
 ```
-Note that due to the deprecation of the `extend()` function, to extend a component when transpiling to ES5, you will need to utilize the following syntax.
+Note that due to the removal of the `extend()` function, to extend a component when transpiling to ES5, you will need to utilize the following syntax.
 ```js
 // My ES5 constructor function extending Component
 function MyComponent(arguments) {


### PR DESCRIPTION
Updates the component guide documentation to provide guidance for extending video.js v8+ components/classes without the `extend()` function that are transpiled to ES5