### PR TITLE
Fix wrong header ids on Guides

### DIFF
--- a/src/components/WithMdxComponents.jsx
+++ b/src/components/WithMdxComponents.jsx
@@ -32,6 +32,9 @@ const StyledLink = styled(Link)`
   margin-left: -20px;
   color: inherit;
   text-decoration: none;
+  &:active, &:focus {
+    outline: none;
+  }
 `;
 
 const StyledHeader = styled(

--- a/src/components/WithMdxComponents.jsx
+++ b/src/components/WithMdxComponents.jsx
@@ -49,13 +49,12 @@ const StyledHeader = styled(
 const getStringChild = children => {
   if (typeof children === 'string') {
     return children;
-  } else if (Array.isArray(children)) {
+  } else if (Array.isArray(children)){
+    let strChild = '';
     for (let child of children) {
-      const strChild = getStringChild(child);
-      if (strChild) {
-        return strChild;
-      }
+      strChild += getStringChild(child);
     }
+    return strChild;
   } else if ('props' in children) {
     return getStringChild(children.props.children);
   }


### PR DESCRIPTION
### Done 
- Fix `getStringChild` function to return right value.
- Remove dotted lines around Link after clicking 
<img width="254" alt="image" src="https://github.com/videojs/videojs.com/assets/57550290/0704172d-1afc-4b49-a3eb-e9ca13881d01">

### QA

- Fix wrong header id
1. Go to /guides/setup
2. Click on `A Note on <video> Tag Attributes` in the Table of Contents
3. **Before fix**:  nothing happens. **After fix**:  it goes to `/guides/setup/#a-note-on-video-tag-attributes`
4. Also, click any header that has backticks( `` )   
for example,  <img width="217" alt="image" src="https://github.com/videojs/videojs.com/assets/57550290/ca12b056-1204-4b67-bc8b-ab5e7819bde5">
6. **Before fix**: it goes to `/guides/setup/#using-`. **After fix**: it goes to `/guides/setup/#using-videojs`
 

- Remove dotted lines around links
1. Go to  /guides/setup and scroll down
2. Click any header. For example "Manual Setup"
**Before fix**: dotted line shows around the link after clicking. **After fix**: no dotted line shows after clicking. 


**Fixes** #153 