### PR TITLE
docs: remove a typo from the responsive option

### DIFF
--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -395,7 +395,7 @@ Setting this option to `true` will cause the player to customize itself based on
 
 When this option is `false` (the default), responsive breakpoints will be ignored.
 
-> Note this is about the responsiveness of the controls within the player, not responsive sizing of the pplayer itself. For that, see [fluid](#fluid).
+> Note this is about the responsiveness of the controls within the player, not responsive sizing of the player itself. For that, see [fluid](#fluid).
 
 ### `restoreEl`
 


### PR DESCRIPTION
## description 

Replace `pplayer` by `player`.