### PR TITLE
docs: add playsinline option

### DIFF
--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -353,6 +353,22 @@ videojs('my-player', {
 });
 ```
 
+### `playsinline`
+
+> Type: `boolean`
+
+_Since 6.1.0_
+
+Indicates to the browser that non-fullscreen playback is preferred when fullscreen playback is the native default, such as in iOS Safari.
+
+For example:
+
+```js
+videojs('my-player', {
+  playsinline: true
+});
+```
+
 ### `plugins`
 
 > Type: `Object`


### PR DESCRIPTION
## Description

Documents the `playsinline` option introduced in videojs [6.1.0](https://github.com/videojs/video.js/releases/tag/v6.1.0).

Refers videojs/video.js#4348