### PR TITLE
fix: Document picture-in-picture is no longer behind an origin trial

### DIFF
--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -199,7 +199,7 @@ This option is inherited from the [`Component` base class](#component-options).
 
 If `true`, switching the video element into picture-in-picture is disabled. Default is `false`.
 
-This has no effect on Firefox, which implements a proprietary picture-in-picture mode which does not implement the standard picture-in-picture API.
+This has no effect on Firefox's proprietary picture-in-picture mode which does not implement the standard picture-in-picture API.
 
 This does not disable the document picture-in-picture mode which allows the player element to put into a PiP window.
 
@@ -211,7 +211,7 @@ _Since 8.3.0_
 
 If `true`, the [documentPictureInPicture API](https://developer.chrome.com/docs/web-platform/document-picture-in-picture/) will be used for picture-in-picture, if available. Defaults to `false`, but may default to `true` when the feature has become established.
 
-Currently this is available in Chrome 111+ as an origin trial.
+Supported by [Chrome and Edge from version 116](https://caniuse.com/mdn-api_documentpictureinpicture).
 
 This is a different picture-in-picture mode than has previously been available, where the entire player element is windowed rather than just the video itself. Since there are scenarios where it would be desirable to allow PiP on the player but not PiP on the video alone (such as ads, overlays), the `disablePictureInPicture` option **only** disables the old-style picture-in-picture mode on the video.
 

--- a/src/mdx-pages/guides/picture-in-picture.mdx
+++ b/src/mdx-pages/guides/picture-in-picture.mdx
@@ -26,7 +26,7 @@ _Added in v8.3.0_
 
 [Document picture-in-picture][doc-pip] is an improved approach where the whole player element can be placed in a PiP window rather than just the video. This allows player controls, text tracks, overlays to be used.
 
-Currently this is supported on Chrome 111 and above as an [origin trial][origin-trial]. The player at [videojs.com](/) will use this mode on supported browsers.
+Currently this is supported on Chrome and Edge 116 and above. The player at [videojs.com](/) will use this mode on supported browsers.
 
 At this time this mode defaults to off, but [can be simply enabled with a player option][enable-docpip]. If enabled, and supported by the browser, this takes prcedence over the video picture-in-picture mode.
 


### PR DESCRIPTION
Updates document picture in picture docs to remove reference to origin trial.