### PR TITLE
fix: Change npm search as API response has changed

### DIFF
--- a/download-plugins.js
+++ b/download-plugins.js
@@ -2,7 +2,7 @@ const https = require('https');
 const fs = require('fs');
 const Promise = require('bluebird');
 
-const pluginsUrl = new URL('https://registry.npmjs.org/-/v1/search?text=keywords:videojs,videojs-plugin,videojs-skin&size=250');
+const pluginsUrl = new URL('https://registry.npmjs.org/-/v1/search?text=keywords:videojs&size=250');
 
 function get(url) {
   return new Promise(function(fulfill, reject) {


### PR DESCRIPTION
The build script is failing as the plugins list is empty due to a change in NPM's search API behavior. This seems to be an [NPM bug](https://github.com/orgs/community/discussions/154222), so this is just a quick and hopefully temporary fix.

Changes search query to all packages tagged `videojs` rather than `videojs,videojs-plugin,videojs-skin`.

