### PR TITLE
fix(docs): typo in control bar options

### DIFF
--- a/src/mdx-pages/guides/options.mdx
+++ b/src/mdx-pages/guides/options.mdx
@@ -47,7 +47,7 @@ player.autoplay('muted');
 
 > Type: `boolean`
 
-Bu default the remaining time display shows as negative time. To not show the negative sign set `controlBar.remainingTimeDisplay.displayNegative` to `false`.
+By default the remaining time display shows as negative time. To not show the negative sign set `controlBar.remainingTimeDisplay.displayNegative` to `false`.
 
 ### `controls`
 


### PR DESCRIPTION
Replace "Bu default" by "By default"