### PR TITLE
fix: /getting-started crashes on client-side navigation (illegal \8 escape)

### DIFF
--- a/src/components/GettingStartedComponents/GettingStartedArticle.jsx
+++ b/src/components/GettingStartedComponents/GettingStartedArticle.jsx
@@ -34,7 +34,7 @@ const Wrapper = styled.article`
 const GettingStartedArticle = ({ mdxData }) => (
   <Wrapper>
     <WithMdxComponents contentSlug={mdxData.fields.slug}>
-      <MDXRenderer>{mdxData.body.replace(/\$\{VJS_VERSION\}/g, version.version)}</MDXRenderer>
+      <MDXRenderer>{mdxData.body.replace(/\\?\$\{VJS_VERSION\}/g, version.version)}</MDXRenderer>
     </WithMdxComponents>
   </Wrapper>
 );


### PR DESCRIPTION
## Problem

Client-side navigation to `/getting-started` (clicking **Get Started** in the navbar, hero, or footer) throws a `SyntaxError` and the page fails to render. A hard reload works, because the page is then server-rendered and never hits the failing code path.

The error (Chrome wording; Firefox phrases the same parse failure as *"The only valid numeric escape in strict mode is '\0'"*):

```
SyntaxError: \8 and \9 are not allowed in template strings.
    at new Function (<anonymous>)        ← MDXRenderer compiling the page body
```

## Root cause

`GettingStartedArticle.jsx` substitutes the version into the **already-compiled** MDX body:

```js
mdxData.body.replace(/\$\{VJS_VERSION\}/g, version.version)
```

Compiled MDX wraps text in template literals and escapes the placeholder as `` `…v\${VJS_VERSION}…` `` to keep it literal. The regex only matched `${VJS_VERSION}`, so it stripped that part but left the leading backslash, producing `v\8.23.7`. Inside a template literal `\8` is an illegal escape, so `MDXRenderer`'s `new Function(...)` throws when it evaluates the body during client-side navigation.

Because the current `video.js` version starts with `8`, the leftover backslash forms `\8`. A version starting with a non-escape character would have masked the bug — so this was latent and surfaced on a fresh MDX recompile, not from any specific content change.

## Fix

Match an optional leading backslash so the placeholder is fully consumed regardless of how MDX compiles it:

```js
mdxData.body.replace(/\\?\$\{VJS_VERSION\}/g, version.version)
```

Verified against the actual deployed broken body: the old regex throws on `new Function`, the new one compiles and renders `currently v8.23.7`.

## Test plan

- [ ] `npm run build`
- [ ] Navigate to `/getting-started` **via in-app click** (navbar / hero / footer) — page renders, no console `SyntaxError`
- [ ] Version string in the intro paragraph and CDN snippets reads `8.23.7` (no stray backslash)

## Follow-up (not in this PR)

The sturdier fix is to stop string-replacing compiled MDX altogether — inject the version as an MDX scope variable / shortcode (e.g. via `MDXProvider`) instead of a text placeholder. This one-liner unblocks the site safely in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)